### PR TITLE
Fix double-lock deadlock with SemaphoreSlim and GameServer, fix sockets going stale after a client uncleanly disconnects and add adjustable logging post build

### DIFF
--- a/Bombd/Core/BombdConfig.cs
+++ b/Bombd/Core/BombdConfig.cs
@@ -66,6 +66,11 @@ public class BombdConfig
     ///     How many times each service performs an update in a second.
     /// </summary>
     public int TickRate { get; set; } = 15;
+
+    /// <summary>
+    ///     The maximum log level to log messages from.
+    /// </summary>
+    public string MaxLogLevel { get; set; } = Enum.GetName(LogLevel.Info);
     
     /// <summary>
     ///     Whether or not connections from LittleBigPlanet Karting are allowed.

--- a/Bombd/Core/BombdService.cs
+++ b/Bombd/Core/BombdService.cs
@@ -167,6 +167,7 @@ public abstract class BombdService
         int userId = CryptoHelper.StringHash32Upper(ticket.Username + (isRPCN ? "RPCN" : "PSN"));
         if (UserInfo.ContainsKey(userId))
         {
+            Logger.LogError(_type, $"User already has a session with state {UserInfo[userId].State}");
             response.Error = "alreadyLoggedIn";
             return false;
         }

--- a/Bombd/Core/BombdService.cs
+++ b/Bombd/Core/BombdService.cs
@@ -167,7 +167,6 @@ public abstract class BombdService
         int userId = CryptoHelper.StringHash32Upper(ticket.Username + (isRPCN ? "RPCN" : "PSN"));
         if (UserInfo.ContainsKey(userId))
         {
-            Logger.LogError(_type, $"User already has a session with state {UserInfo[userId].State}");
             response.Error = "alreadyLoggedIn";
             return false;
         }

--- a/Bombd/Core/RoomManager.cs
+++ b/Bombd/Core/RoomManager.cs
@@ -110,7 +110,8 @@ public class RoomManager
         request.Attributes["__JOIN_MODE"] = "OPEN";
         request.Attributes["__MM_MODE_G"] = "OPEN";
         request.Attributes["__MM_MODE_P"] = "OPEN";
-        
+        request.Attributes["IS_LOCKED"] = "0";
+
         // Set default server type if none was provided, although this
         // generally shouldn't happen
         request.Attributes.TryAdd("SERVER_TYPE", "kartPark");
@@ -253,10 +254,6 @@ public class RoomManager
                 // before advertising the session.
                 if (!room.Simulation.HasRaceSettings)
                     return false;
-                
-                // If the race is already in progress, don't advertise the session
-                if (room.Simulation.RaceState >= RaceState.LoadingIntoRace || !room.Simulation.CanJoinAsRacer())
-                    return false;
             }
             
             foreach (KeyValuePair<string, string> attribute in attributes)
@@ -285,7 +282,8 @@ public class RoomManager
             attr["__MM_MODE_G"] = visibility;
             attr["__MM_MODE_P"] = visibility;
             attr["__JOIN_MODE"] = visibility;
-            
+            attr["IS_LOCKED"] = (room.Simulation.RaceState >= RaceState.LoadingIntoRace || !room.Simulation.CanJoinAsRacer()) ? "1" : "0";
+
             attr["__MAX_PLAYERS"] = settings.MaxHumans.ToString();
             
             // TODO: Adjust player counts on Karting?

--- a/Bombd/Core/RoomManager.cs
+++ b/Bombd/Core/RoomManager.cs
@@ -255,8 +255,8 @@ public class RoomManager
                 if (!room.Simulation.HasRaceSettings)
                     return false;
 
-                // Joining in this state causes issues, to find out why
-                if (room.Simulation.RaceState == RaceState.LoadingIntoRace)
+                // For now just prevent joins into in-progress lobbies entirely, causes instability
+                if (room.Simulation.RaceState >= RaceState.LoadingIntoRace || !room.Simulation.CanJoinAsRacer())
                     return false;
             }
             

--- a/Bombd/Core/RoomManager.cs
+++ b/Bombd/Core/RoomManager.cs
@@ -286,7 +286,7 @@ public class RoomManager
             attr["__MM_MODE_G"] = visibility;
             attr["__MM_MODE_P"] = visibility;
             attr["__JOIN_MODE"] = visibility;
-            attr["IS_LOCKED"] = (room.Simulation.RaceState >= RaceState.LoadingIntoRace || !room.Simulation.CanJoinAsRacer()) ? "1" : "0";
+            attr["IS_LOCKED"] = (room.Simulation != null && (room.Simulation.RaceState >= RaceState.LoadingIntoRace || !room.Simulation.CanJoinAsRacer())) ? "1" : "0";
 
             attr["__MAX_PLAYERS"] = settings.MaxHumans.ToString();
             

--- a/Bombd/Core/RoomManager.cs
+++ b/Bombd/Core/RoomManager.cs
@@ -254,6 +254,10 @@ public class RoomManager
                 // before advertising the session.
                 if (!room.Simulation.HasRaceSettings)
                     return false;
+
+                // Joining in this state causes issues, to find out why
+                if (room.Simulation.RaceState == RaceState.LoadingIntoRace)
+                    return false;
             }
             
             foreach (KeyValuePair<string, string> attribute in attributes)

--- a/Bombd/Core/SimServer.cs
+++ b/Bombd/Core/SimServer.cs
@@ -420,6 +420,8 @@ public class SimServer
             { 
                 BroadcastPlayerState();
                 SwitchAllToRacers();
+                if (_raceSettings != null)
+                    Room.UpdateAttributes(_raceSettings.Value);
                 break;
             }
             case RoomState.RaceInProgress:
@@ -427,6 +429,8 @@ public class SimServer
                 StartEvent();
                 BroadcastSessionInfo();
                 BroadcastPlayerState();
+                if (_raceSettings != null)
+                    Room.UpdateAttributes(_raceSettings.Value);
                 break;
             }
             case RoomState.Ready:

--- a/Bombd/Data/Matchmaking/ModNation.xml
+++ b/Bombd/Data/Matchmaking/ModNation.xml
@@ -37,3 +37,5 @@
     <PossibleValue>kartPark</PossibleValue>
     <PossibleValue>competitive</PossibleValue>
 </SimpleFilter>
+
+<NumberPreference name="IS_LOCKED" range="1.0" weight="1.0" default="0.0"></NumberPreference>

--- a/Bombd/Logging/Logger.cs
+++ b/Bombd/Logging/Logger.cs
@@ -6,13 +6,8 @@ namespace Bombd.Logging;
 
 public class Logger
 {
-#if DEBUG
-    private const LogLevel MaxLevel = LogLevel.Trace;
-#else
-    private const LogLevel MaxLevel = LogLevel.Info;
-#endif
-    
     private static readonly ConcurrentQueue<LogEntry> LogQueue = new();
+    private static LogLevel MaxLevel = LogLevel.Info;
 
     static Logger()
     {
@@ -47,6 +42,8 @@ public class Logger
             _ => ConsoleColor.White
         };
     }
+
+    public static void SetLogMaxLevel(LogLevel level) => MaxLevel = level;
 
     public static void LogError<T>(string message) => Log<T>(LogLevel.Error, message);
     public static void LogWarning<T>(string message) => Log<T>(LogLevel.Warning, message);

--- a/Bombd/Logging/Logger.cs
+++ b/Bombd/Logging/Logger.cs
@@ -49,10 +49,8 @@ public class Logger
     public static void LogWarning<T>(string message) => Log<T>(LogLevel.Warning, message);
     public static void LogInfo<T>(string message) => Log<T>(LogLevel.Info, message);
     
-    [Conditional("DEBUG")]
     public static void LogDebug<T>(string message) => Log<T>(LogLevel.Debug, message);
     
-    [Conditional("DEBUG")]
     public static void LogTrace<T>(string message) => Log<T>(LogLevel.Trace, message);
     
     public static void Log<T>(LogLevel level, string message)
@@ -64,10 +62,8 @@ public class Logger
     public static void LogWarning(Type type, string message) => Log(type, LogLevel.Warning, message);
     public static void LogInfo(Type type, string message) => Log(type, LogLevel.Info, message);
     
-    [Conditional("DEBUG")]
     public static void LogDebug(Type type, string message) => Log(type, LogLevel.Debug, message);
     
-    [Conditional("DEBUG")]
     public static void LogTrace(Type type, string message) => Log(type, LogLevel.Trace, message);
 
     public static void Log(Type type, LogLevel level, string message)

--- a/Bombd/Program.cs
+++ b/Bombd/Program.cs
@@ -3,9 +3,7 @@ using Bombd.Logging;
 using Bombd.Services;
 using Directory = Bombd.Services.Directory;
 
-var logLevel = Enum.Parse<LogLevel>(BombdConfig.Instance.MaxLogLevel);
-Logger.SetLogMaxLevel(logLevel);
-Logger.LogInfo<Program>($"Max log level is now {BombdConfig.Instance.MaxLogLevel} ({logLevel})");
+Logger.SetLogMaxLevel(Enum.Parse<LogLevel>(BombdConfig.Instance.MaxLogLevel));
 
 string certificate = BombdConfig.Instance.PfxCertificate;
 if (string.IsNullOrEmpty(certificate))

--- a/Bombd/Program.cs
+++ b/Bombd/Program.cs
@@ -3,7 +3,9 @@ using Bombd.Logging;
 using Bombd.Services;
 using Directory = Bombd.Services.Directory;
 
-Logger.SetLogMaxLevel(Enum.Parse<LogLevel>(BombdConfig.Instance.MaxLogLevel));
+var logLevel = Enum.Parse<LogLevel>(BombdConfig.Instance.MaxLogLevel);
+Logger.SetLogMaxLevel(logLevel);
+Logger.LogDebug<Program>($"Max log level is now {BombdConfig.Instance.MaxLogLevel} ({logLevel})");
 
 string certificate = BombdConfig.Instance.PfxCertificate;
 if (string.IsNullOrEmpty(certificate))

--- a/Bombd/Program.cs
+++ b/Bombd/Program.cs
@@ -5,7 +5,7 @@ using Directory = Bombd.Services.Directory;
 
 var logLevel = Enum.Parse<LogLevel>(BombdConfig.Instance.MaxLogLevel);
 Logger.SetLogMaxLevel(logLevel);
-Logger.LogDebug<Program>($"Max log level is now {BombdConfig.Instance.MaxLogLevel} ({logLevel})");
+Logger.LogInfo<Program>($"Max log level is now {BombdConfig.Instance.MaxLogLevel} ({logLevel})");
 
 string certificate = BombdConfig.Instance.PfxCertificate;
 if (string.IsNullOrEmpty(certificate))

--- a/Bombd/Program.cs
+++ b/Bombd/Program.cs
@@ -3,6 +3,8 @@ using Bombd.Logging;
 using Bombd.Services;
 using Directory = Bombd.Services.Directory;
 
+Logger.SetLogMaxLevel(Enum.Parse<LogLevel>(BombdConfig.Instance.MaxLogLevel));
+
 string certificate = BombdConfig.Instance.PfxCertificate;
 if (string.IsNullOrEmpty(certificate))
 {

--- a/Bombd/Properties/launchSettings.json
+++ b/Bombd/Properties/launchSettings.json
@@ -1,10 +1,17 @@
 {
-  "profiles": {
-    "Bombd": {
-      "commandName": "Project"
-    },
-    "Docker": {
-      "commandName": "Docker"
+    "profiles": {
+        "Bombd": {
+            "commandName": "Project"
+        },
+        "Docker": {
+            "commandName": "Docker"
+        },
+        "WSL": {
+            "commandName": "WSL2",
+            "environmentVariables": {
+                "LD_LIBRARY_PATH": "/usr/local/lib64:/usr/local/lib:/usr/lib",
+                "OPENSSL_CONF": "/etc/ssl/openssl.cnf"
+            }
+        }
     }
-  }
 }

--- a/Bombd/Protocols/ConnectionBase.cs
+++ b/Bombd/Protocols/ConnectionBase.cs
@@ -11,7 +11,7 @@ public abstract class ConnectionBase
     public readonly IServer Server;
 
     public readonly BombdService Service;
-    protected ConnectionState State = ConnectionState.Disconnected;
+    public ConnectionState State = ConnectionState.Disconnected;
 
     protected ConnectionBase(BombdService service, IServer server)
     {

--- a/Bombd/Protocols/TCP/SslConnection.cs
+++ b/Bombd/Protocols/TCP/SslConnection.cs
@@ -207,9 +207,10 @@ public class SslConnection : ConnectionBase
                     } while (offset < payloadSize);
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 Logger.LogError<SslConnection>("An error occurred while reading from socket. Closing connection.");
+                Logger.LogDebug<SslConnection>(ex.ToString());
                 Disconnect();
                 return;
             }

--- a/Bombd/Protocols/TCP/SslConnection.cs
+++ b/Bombd/Protocols/TCP/SslConnection.cs
@@ -149,9 +149,10 @@ public class SslConnection : ConnectionBase
                     offset += size;
                 } while (offset < messageSize);
             }
-            catch (Exception)
+            catch (Exception e)
             {
                 Logger.LogError<SslConnection>("An error occurred during send. Closing connection.");
+                Logger.LogDebug<SslConnection>(e.ToString());
                 Disconnect();
             }
         }
@@ -207,10 +208,10 @@ public class SslConnection : ConnectionBase
                     } while (offset < payloadSize);
                 }
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
                 Logger.LogError<SslConnection>("An error occurred while reading from socket. Closing connection.");
-                Logger.LogDebug<SslConnection>(ex.ToString());
+                Logger.LogDebug<SslConnection>(e.ToString());
                 Disconnect();
                 return;
             }


### PR DESCRIPTION
This fixes an issue where, in specific circumstances, a single thread would call SemaphoreSlim.Wait twice, causing a deadlock as the second wait will wait on the first wait to be released, which cannot be released as the thread is halted.

This PR also adds the necessary WSL debug environment variables (let me know if these need to be removed but I dont see an issue as it removes steps from setting up a debug environment) and also allows adjustment of logging outside the debug environment which is useful for troubleshooting